### PR TITLE
chore: importa picker desde `react-native`

### DIFF
--- a/src/BetterPicker/BetterPicker.tsx
+++ b/src/BetterPicker/BetterPicker.tsx
@@ -1,4 +1,4 @@
-import { Picker } from '@react-native-community/picker';
+import { Picker } from 'react-native';
 import React from 'react';
 import type { PickerProperties } from './index';
 


### PR DESCRIPTION
cambia picker from @react-native-community/picker por picker from react-native para compatibilidad con expo sdk 37